### PR TITLE
Cvars sv_unlimited_pickup and cl_huddigits to tweak the hud width for…

### DIFF
--- a/client/cl_main.c
+++ b/client/cl_main.c
@@ -46,6 +46,7 @@ cvar_t	*cl_timeout;
 cvar_t	*cl_predict;
 //cvar_t	*cl_minfps;
 cvar_t	*cl_maxfps;
+cvar_t	*cl_huddigits;//alex3474247
 cvar_t	*cl_sleep;	// Knightmare- whether to enable CPU usage fix
 cvar_t	*cl_gun;
 
@@ -1531,6 +1532,7 @@ void CL_InitLocal (void)
 	cl_predict = Cvar_Get ("cl_predict", "1", 0);
 //	cl_minfps = Cvar_Get ("cl_minfps", "5", 0);
 	cl_maxfps = Cvar_Get ("cl_maxfps", "90", 0);
+	cl_huddigits = Cvar_Get ("cl_huddigits", "3", 0);
 
 	cl_sleep = Cvar_Get ("cl_sleep", "1", 0);	// Knightmare- whether to enable CPU usage fix
 
@@ -1668,15 +1670,8 @@ void CL_WriteConfiguration (char *cfgName)
 	if (cls.state == ca_uninitialized)
 		return;
 
-    // Create directories
-	//Sys_Mkdir(".q2");
-	//Com_sprintf (path, sizeof(path),".q2/%s/", FS_Gamedir());
-    //Sys_Mkdir(path);
-
 	Com_sprintf (path, sizeof(path),"%s/config.cfg", FS_Gamedir());
-//	Com_sprintf (path, sizeof(path),".q2/%s/%s.cfg", FS_Gamedir(), cfgName);
-
-
+//	Com_sprintf (path, sizeof(path),"%s/%s.cfg", FS_Gamedir(), cfgName);
 	f = fopen (path, "w");
 	if (!f)
 	{

--- a/client/cl_scrn.c
+++ b/client/cl_scrn.c
@@ -1163,7 +1163,15 @@ void SCR_ExecuteLayoutString (char *s)
 		{	// health number
 			int		color;
 
-			width = 3;
+			if (!cl_huddigits->value)
+			{
+				width = 3;
+			}
+			else
+			{
+				width = cl_huddigits->value;
+			}
+
 			value = cl.frame.playerstate.stats[STAT_HEALTH];
 			if (value > 25)
 				color = 0;	// green
@@ -1175,7 +1183,7 @@ void SCR_ExecuteLayoutString (char *s)
 			if (cl.frame.playerstate.stats[STAT_FLASHES] & 1)
 				re.DrawPic (x, y, "field_3");
 
-			SCR_DrawField (x, y, color, width, value);
+			SCR_DrawField (x-16*(width-3), y, color, width, value);
 			continue;
 		}
 
@@ -1183,7 +1191,14 @@ void SCR_ExecuteLayoutString (char *s)
 		{	// ammo number
 			int		color;
 
-			width = 3;
+			if (!cl_huddigits->value)
+			{
+				width = 3;
+			}
+			else
+			{
+				width = cl_huddigits->value;
+			}
 			value = cl.frame.playerstate.stats[STAT_AMMO];
 			if (value > 5)
 				color = 0;	// green
@@ -1195,7 +1210,7 @@ void SCR_ExecuteLayoutString (char *s)
 			if (cl.frame.playerstate.stats[STAT_FLASHES] & 4)
 				re.DrawPic (x, y, "field_3");
 
-			SCR_DrawField (x, y, color, width, value);
+			SCR_DrawField (x-16*(width-3), y, color, width, value);
 			continue;
 		}
 
@@ -1203,7 +1218,14 @@ void SCR_ExecuteLayoutString (char *s)
 		{	// armor number
 			int		color;
 
-			width = 3;
+			if (!cl_huddigits->value)
+			{
+				width = 3;
+			}
+			else
+			{
+				width = cl_huddigits->value;
+			}
 			value = cl.frame.playerstate.stats[STAT_ARMOR];
 			if (value < 1)
 				continue;
@@ -1213,7 +1235,7 @@ void SCR_ExecuteLayoutString (char *s)
 			if (cl.frame.playerstate.stats[STAT_FLASHES] & 2)
 				re.DrawPic (x, y, "field_3");
 
-			SCR_DrawField (x, y, color, width, value);
+			SCR_DrawField (x-16*(width-3), y, color, width, value);
 			continue;
 		}
 

--- a/client/client.h
+++ b/client/client.h
@@ -274,6 +274,7 @@ extern	cvar_t	*cl_yawspeed;
 extern	cvar_t	*cl_pitchspeed;
 
 extern	cvar_t	*cl_run;
+extern	cvar_t	*cl_huddigits;//alex3474247
 
 extern	cvar_t	*cl_anglespeedkey;
 

--- a/game/g_items.c
+++ b/game/g_items.c
@@ -40,9 +40,9 @@ gitem_armor_t jacketarmor_info	= { 25,  50, .30, .00, ARMOR_JACKET};
 gitem_armor_t combatarmor_info	= { 50, 100, .60, .30, ARMOR_COMBAT};
 gitem_armor_t bodyarmor_info	= {100, 200, .80, .60, ARMOR_BODY};
 
- int	jacket_armor_index;
- int	combat_armor_index;
- int	body_armor_index;
+static int	jacket_armor_index;
+static int	combat_armor_index;
+static int	body_armor_index;
 static int	power_screen_index;
 static int	power_shield_index;
 
@@ -161,14 +161,18 @@ qboolean Pickup_Powerup (edict_t *ent, edict_t *other)
 	int		quantity;
 
 	quantity = other->client->pers.inventory[ITEM_INDEX(ent->item)];
-	if ((skill->value == 1 && quantity >= 2) || (skill->value >= 2 && quantity >= 1))
-		return false;
-
+	
+	if(!sv_unlimited_pickup->value)
+	{
+		if ((skill->value == 1 && quantity >= 2) || (skill->value >= 2 && quantity >= 1))
+			return false;
+	}
+	
 	if ((coop->value) && (ent->item->flags & IT_STAY_COOP) && (quantity > 0))
 		return false;
-
+	
 	other->client->pers.inventory[ITEM_INDEX(ent->item)]++;
-
+	
 	if (deathmatch->value)
 	{
 		if (!(ent->spawnflags & DROPPED_ITEM) )
@@ -199,8 +203,15 @@ qboolean Pickup_Adrenaline (edict_t *ent, edict_t *other)
 	if (!deathmatch->value)
 		other->max_health += 1;
 
-	if (other->health < other->max_health)
-		other->health = other->max_health;
+	if(!sv_unlimited_pickup->value)
+	{
+		if (other->health < other->max_health)
+			other->health = other->max_health;
+	}
+	else
+	{
+		other->health += 150;
+	}
 
 	if (!(ent->spawnflags & DROPPED_ITEM) && (deathmatch->value))
 		SetRespawn (ent, ent->item->quantity);
@@ -223,6 +234,8 @@ qboolean Pickup_Bandolier (edict_t *ent, edict_t *other)
 	gitem_t	*item;
 	int		index;
 
+	if (!sv_unlimited_pickup->value)	
+	{
 	if (other->client->pers.max_bullets < 250)
 		other->client->pers.max_bullets = 250;
 	if (other->client->pers.max_shells < 150)
@@ -231,14 +244,17 @@ qboolean Pickup_Bandolier (edict_t *ent, edict_t *other)
 		other->client->pers.max_cells = 250;
 	if (other->client->pers.max_slugs < 75)
 		other->client->pers.max_slugs = 75;
-
+	}
 	item = FindItem("Bullets");
 	if (item)
 	{
 		index = ITEM_INDEX(item);
 		other->client->pers.inventory[index] += item->quantity;
+		if (!sv_unlimited_pickup->value)
+		{
 		if (other->client->pers.inventory[index] > other->client->pers.max_bullets)
 			other->client->pers.inventory[index] = other->client->pers.max_bullets;
+		}
 	}
 
 	item = FindItem("Shells");
@@ -246,8 +262,11 @@ qboolean Pickup_Bandolier (edict_t *ent, edict_t *other)
 	{
 		index = ITEM_INDEX(item);
 		other->client->pers.inventory[index] += item->quantity;
+		if (!sv_unlimited_pickup->value)
+		{
 		if (other->client->pers.inventory[index] > other->client->pers.max_shells)
 			other->client->pers.inventory[index] = other->client->pers.max_shells;
+		}
 	}
 
 	if (!(ent->spawnflags & DROPPED_ITEM) && (deathmatch->value))
@@ -261,6 +280,8 @@ qboolean Pickup_Pack (edict_t *ent, edict_t *other)
 	gitem_t	*item;
 	int		index;
 
+	if (!sv_unlimited_pickup->value)	
+	{
 	if (other->client->pers.max_bullets < 300)
 		other->client->pers.max_bullets = 300;
 	if (other->client->pers.max_shells < 200)
@@ -273,14 +294,18 @@ qboolean Pickup_Pack (edict_t *ent, edict_t *other)
 		other->client->pers.max_cells = 300;
 	if (other->client->pers.max_slugs < 100)
 		other->client->pers.max_slugs = 100;
+	}
 
 	item = FindItem("Bullets");
 	if (item)
 	{
 		index = ITEM_INDEX(item);
 		other->client->pers.inventory[index] += item->quantity;
+		if (!sv_unlimited_pickup->value)
+		{
 		if (other->client->pers.inventory[index] > other->client->pers.max_bullets)
 			other->client->pers.inventory[index] = other->client->pers.max_bullets;
+		}
 	}
 
 	item = FindItem("Shells");
@@ -288,8 +313,11 @@ qboolean Pickup_Pack (edict_t *ent, edict_t *other)
 	{
 		index = ITEM_INDEX(item);
 		other->client->pers.inventory[index] += item->quantity;
+		if (!sv_unlimited_pickup->value)
+		{
 		if (other->client->pers.inventory[index] > other->client->pers.max_shells)
 			other->client->pers.inventory[index] = other->client->pers.max_shells;
+		}
 	}
 
 	item = FindItem("Cells");
@@ -297,8 +325,11 @@ qboolean Pickup_Pack (edict_t *ent, edict_t *other)
 	{
 		index = ITEM_INDEX(item);
 		other->client->pers.inventory[index] += item->quantity;
+		if (!sv_unlimited_pickup->value)
+		{
 		if (other->client->pers.inventory[index] > other->client->pers.max_cells)
 			other->client->pers.inventory[index] = other->client->pers.max_cells;
+		}
 	}
 
 	item = FindItem("Grenades");
@@ -306,8 +337,11 @@ qboolean Pickup_Pack (edict_t *ent, edict_t *other)
 	{
 		index = ITEM_INDEX(item);
 		other->client->pers.inventory[index] += item->quantity;
+		if (!sv_unlimited_pickup->value)
+		{
 		if (other->client->pers.inventory[index] > other->client->pers.max_grenades)
 			other->client->pers.inventory[index] = other->client->pers.max_grenades;
+		}
 	}
 
 	item = FindItem("Rockets");
@@ -315,8 +349,11 @@ qboolean Pickup_Pack (edict_t *ent, edict_t *other)
 	{
 		index = ITEM_INDEX(item);
 		other->client->pers.inventory[index] += item->quantity;
+		if (!sv_unlimited_pickup->value)
+		{
 		if (other->client->pers.inventory[index] > other->client->pers.max_rockets)
 			other->client->pers.inventory[index] = other->client->pers.max_rockets;
+		}
 	}
 
 	item = FindItem("Slugs");
@@ -324,8 +361,11 @@ qboolean Pickup_Pack (edict_t *ent, edict_t *other)
 	{
 		index = ITEM_INDEX(item);
 		other->client->pers.inventory[index] += item->quantity;
+		if (!sv_unlimited_pickup->value)
+		{
 		if (other->client->pers.inventory[index] > other->client->pers.max_slugs)
 			other->client->pers.inventory[index] = other->client->pers.max_slugs;
+		}
 	}
 
 	if (!(ent->spawnflags & DROPPED_ITEM) && (deathmatch->value))
@@ -468,14 +508,20 @@ qboolean Add_Ammo (edict_t *ent, gitem_t *item, int count)
 		return false;
 
 	index = ITEM_INDEX(item);
-
-	if (ent->client->pers.inventory[index] == max)
-		return false;
-
+	if(sv_unlimited_pickup->value)
+	{
 	ent->client->pers.inventory[index] += count;
+	}
+	else
+	{
+		if (ent->client->pers.inventory[index] == max)
+			return false;
 
-	if (ent->client->pers.inventory[index] > max)
-		ent->client->pers.inventory[index] = max;
+		ent->client->pers.inventory[index] += count;
+
+		if (ent->client->pers.inventory[index] > max)
+			ent->client->pers.inventory[index] = max;
+	}
 
 	return true;
 }
@@ -540,13 +586,18 @@ void Drop_Ammo (edict_t *ent, gitem_t *item)
 
 void MegaHealth_think (edict_t *self)
 {
-	if (self->owner->health > self->owner->max_health)
+	if(!sv_unlimited_pickup->value)
 	{
-		self->nextthink = level.time + 1;
-		self->owner->health -= 1;
-		return;
+		if (self->owner->health > self->owner->max_health)
+		{
+			self->nextthink = level.time + 1;
+			
+			
+			self->owner->health -= 1;
+			
+			return;
+		}
 	}
-
 	if (!(self->spawnflags & DROPPED_ITEM) && (deathmatch->value))
 		SetRespawn (self, 20);
 	else
@@ -555,16 +606,23 @@ void MegaHealth_think (edict_t *self)
 
 qboolean Pickup_Health (edict_t *ent, edict_t *other)
 {
-	if (!(ent->style & HEALTH_IGNORE_MAX))
-		if (other->health >= other->max_health)
-			return false;
-
-	other->health += ent->count;
-
-	if (!(ent->style & HEALTH_IGNORE_MAX))
+	if (sv_unlimited_pickup->value)
 	{
-		if (other->health > other->max_health)
-			other->health = other->max_health;
+		other->health += ent->count;
+	}
+	else
+	{
+		if (!(ent->style & HEALTH_IGNORE_MAX))
+			if (other->health >= other->max_health)
+				return false;
+			
+			other->health += ent->count;
+			
+			if (!(ent->style & HEALTH_IGNORE_MAX))
+			{
+				if (other->health > other->max_health)
+					other->health = other->max_health;
+			}
 	}
 
 	if (ent->style & HEALTH_TIMED)
@@ -644,36 +702,79 @@ qboolean Pickup_Armor (edict_t *ent, edict_t *other)
 		else // (old_armor_index == body_armor_index)
 			oldinfo = &bodyarmor_info;
 
-		if (newinfo->normal_protection > oldinfo->normal_protection)
+		if(sv_unlimited_pickup->value)
 		{
-			// calc new armor values
-			salvage = oldinfo->normal_protection / newinfo->normal_protection;
+		/*if (newinfo->normal_protection > oldinfo->normal_protection)
+		{
+		//	calc new armor values
+		//	salvage = oldinfo->normal_protection / newinfo->normal_protection;
+			salvage = newinfo->normal_protection / oldinfo->normal_protection;
 			salvagecount = salvage * other->client->pers.inventory[old_armor_index];
 			newcount = newinfo->base_count + salvagecount;
 			if (newcount > newinfo->max_count)
 				newcount = newinfo->max_count;
+			newcount = newinfo->base_count + other->client->pers.inventory[old_armor_index];
 
-			// zero count of old armor so it goes away
+			//zero count of old armor so it goes away
 			other->client->pers.inventory[old_armor_index] = 0;
 
-			// change armor to new item with computed value
+			 //change armor to new item with computed value
+		
+			
+
 			other->client->pers.inventory[ITEM_INDEX(ent->item)] = newcount;
+				
 		}
 		else
-		{
+		{*/
 			// calc new armor values
-			salvage = newinfo->normal_protection / oldinfo->normal_protection;
-			salvagecount = salvage * newinfo->base_count;
+			//salvage = newinfo->normal_protection / oldinfo->normal_protection;
+			salvagecount = newinfo->base_count;
 			newcount = other->client->pers.inventory[old_armor_index] + salvagecount;
-			if (newcount > oldinfo->max_count)
-				newcount = oldinfo->max_count;
+			//if (newcount > oldinfo->max_count)
+			//	newcount = oldinfo->max_count;
 
 			// if we're already maxed out then we don't need the new armor
-			if (other->client->pers.inventory[old_armor_index] >= newcount)
-				return false;
+			//if (other->client->pers.inventory[old_armor_index] >= newcount)
+			//	return false;
 
 			// update current armor value
 			other->client->pers.inventory[old_armor_index] = newcount;
+		//}
+		}
+		else
+		{
+			if (newinfo->normal_protection > oldinfo->normal_protection)
+					{
+						// calc new armor values
+						salvage = oldinfo->normal_protection / newinfo->normal_protection;
+						salvagecount = salvage * other->client->pers.inventory[old_armor_index];
+						newcount = newinfo->base_count + salvagecount;
+						if (newcount > newinfo->max_count)
+							newcount = newinfo->max_count;
+
+						// zero count of old armor so it goes away
+						other->client->pers.inventory[old_armor_index] = 0;
+
+						// change armor to new item with computed value
+						other->client->pers.inventory[ITEM_INDEX(ent->item)] = newcount;
+					}
+					else
+					{
+						// calc new armor values
+						salvage = newinfo->normal_protection / oldinfo->normal_protection;
+						salvagecount = salvage * newinfo->base_count;
+						newcount = other->client->pers.inventory[old_armor_index] + salvagecount;
+						if (newcount > oldinfo->max_count)
+							newcount = oldinfo->max_count;
+
+						// if we're already maxed out then we don't need the new armor
+						if (other->client->pers.inventory[old_armor_index] >= newcount)
+							return false;
+
+						// update current armor value
+						other->client->pers.inventory[old_armor_index] = newcount;
+					}
 		}
 	}
 

--- a/game/g_local.h
+++ b/game/g_local.h
@@ -542,6 +542,7 @@ extern	cvar_t	*bob_pitch;
 extern	cvar_t	*bob_roll;
 
 extern	cvar_t	*sv_cheats;
+extern	cvar_t	*sv_unlimited_pickup;//alex3474247
 extern	cvar_t	*maxclients;
 extern	cvar_t	*maxspectators;
 

--- a/game/g_main.c
+++ b/game/g_main.c
@@ -65,6 +65,7 @@ cvar_t	*bob_pitch;
 cvar_t	*bob_roll;
 
 cvar_t	*sv_cheats;
+cvar_t	*sv_unlimited_pickup;//alex3474247
 
 cvar_t	*flood_msgs;
 cvar_t	*flood_persecond;
@@ -367,8 +368,11 @@ void ExitLevel (void)
 		ent = g_edicts + 1 + i;
 		if (!ent->inuse)
 			continue;
-		if (ent->health > ent->client->pers.max_health)
-			ent->health = ent->client->pers.max_health;
+		if(!sv_unlimited_pickup->value)
+		{
+			if (ent->health > ent->client->pers.max_health)
+				ent->health = ent->client->pers.max_health;
+		}
 	}
 
 }

--- a/game/g_save.c
+++ b/game/g_save.c
@@ -170,6 +170,7 @@ void InitGame (void)
 
 	// latched vars
 	sv_cheats = gi.cvar ("cheats", "0", CVAR_SERVERINFO|CVAR_LATCH);
+	sv_unlimited_pickup = gi.cvar ("unlimited_pickup", "0", CVAR_SERVERINFO|CVAR_LATCH);//alex3474247
 	gi.cvar ("gamename", GAMEVERSION , CVAR_SERVERINFO | CVAR_LATCH);
 	gi.cvar ("gamedate", __DATE__ , CVAR_SERVERINFO | CVAR_LATCH);
 

--- a/rsrc/g_items.c
+++ b/rsrc/g_items.c
@@ -34,9 +34,9 @@ gitem_armor_t jacketarmor_info	= { 25,  50, .30, .00, ARMOR_JACKET};
 gitem_armor_t combatarmor_info	= { 50, 100, .60, .30, ARMOR_COMBAT};
 gitem_armor_t bodyarmor_info	= {100, 200, .80, .60, ARMOR_BODY};
 
- int	jacket_armor_index;
- int	combat_armor_index;
- int	body_armor_index;
+static int	jacket_armor_index;
+static int	combat_armor_index;
+static int	body_armor_index;
 static int	power_screen_index;
 static int	power_shield_index;
 
@@ -174,9 +174,12 @@ qboolean Pickup_Powerup (edict_t *ent, edict_t *other)
 	int		quantity;
 
 	quantity = other->client->pers.inventory[ITEM_INDEX(ent->item)];
+
+	if(!sv_unlimited_pickup->value)
+	{
 	if ((skill->value == 1 && quantity >= 2) || (skill->value >= 2 && quantity >= 1))
 		return false;
-
+	}
 	if ((coop->value) && (ent->item->flags & IT_STAY_COOP) && (quantity > 0))
 		return false;
 
@@ -216,10 +219,17 @@ qboolean Pickup_Adrenaline (edict_t *ent, edict_t *other)
 {
 	if (!deathmatch->value)
 		other->max_health += 1;
-
-	if (other->health < other->max_health)
-		other->health = other->max_health;
-
+	
+	if(!sv_unlimited_pickup->value)
+	{
+		if (other->health < other->max_health)
+			other->health = other->max_health;
+	}
+	else
+	{
+		other->health += 150;
+	}
+	
 	if (!(ent->spawnflags & DROPPED_ITEM) && (deathmatch->value))
 		SetRespawn (ent, ent->item->quantity);
 
@@ -240,7 +250,8 @@ qboolean Pickup_Bandolier (edict_t *ent, edict_t *other)
 {
 	gitem_t	*item;
 	int		index;
-
+	if(!sv_unlimited_pickup->value)
+	{
 	if (other->client->pers.max_bullets < 250)
 		other->client->pers.max_bullets = 250;
 	if (other->client->pers.max_shells < 150)
@@ -257,14 +268,18 @@ qboolean Pickup_Bandolier (edict_t *ent, edict_t *other)
 		other->client->pers.max_rounds = 150;
 #endif
 	//pmm
-
+	}
 	item = FindItem("Bullets");
 	if (item)
 	{
 		index = ITEM_INDEX(item);
 		other->client->pers.inventory[index] += item->quantity;
+
+		if(!sv_unlimited_pickup->value)
+		{
 		if (other->client->pers.inventory[index] > other->client->pers.max_bullets)
 			other->client->pers.inventory[index] = other->client->pers.max_bullets;
+		}
 	}
 
 	item = FindItem("Shells");
@@ -272,8 +287,12 @@ qboolean Pickup_Bandolier (edict_t *ent, edict_t *other)
 	{
 		index = ITEM_INDEX(item);
 		other->client->pers.inventory[index] += item->quantity;
+
+		if(!sv_unlimited_pickup->value)
+		{
 		if (other->client->pers.inventory[index] > other->client->pers.max_shells)
 			other->client->pers.inventory[index] = other->client->pers.max_shells;
+		}
 	}
 
 	if (!(ent->spawnflags & DROPPED_ITEM) && (deathmatch->value))
@@ -287,6 +306,8 @@ qboolean Pickup_Pack (edict_t *ent, edict_t *other)
 	gitem_t	*item;
 	int		index;
 
+	if(!sv_unlimited_pickup->value)
+	{
 	if (other->client->pers.max_bullets < 300)
 		other->client->pers.max_bullets = 300;
 	if (other->client->pers.max_shells < 200)
@@ -307,14 +328,18 @@ qboolean Pickup_Pack (edict_t *ent, edict_t *other)
 		other->client->pers.max_rounds = 200;
 #endif
 	//pmm
-
+	}
 	item = FindItem("Bullets");
 	if (item)
 	{
 		index = ITEM_INDEX(item);
 		other->client->pers.inventory[index] += item->quantity;
+
+		if(!sv_unlimited_pickup->value)
+		{
 		if (other->client->pers.inventory[index] > other->client->pers.max_bullets)
 			other->client->pers.inventory[index] = other->client->pers.max_bullets;
+		}
 	}
 
 	item = FindItem("Shells");
@@ -322,8 +347,12 @@ qboolean Pickup_Pack (edict_t *ent, edict_t *other)
 	{
 		index = ITEM_INDEX(item);
 		other->client->pers.inventory[index] += item->quantity;
+
+		if(!sv_unlimited_pickup->value)
+		{
 		if (other->client->pers.inventory[index] > other->client->pers.max_shells)
 			other->client->pers.inventory[index] = other->client->pers.max_shells;
+		}
 	}
 
 	item = FindItem("Cells");
@@ -331,8 +360,12 @@ qboolean Pickup_Pack (edict_t *ent, edict_t *other)
 	{
 		index = ITEM_INDEX(item);
 		other->client->pers.inventory[index] += item->quantity;
+		
+		if(!sv_unlimited_pickup->value)
+		{
 		if (other->client->pers.inventory[index] > other->client->pers.max_cells)
 			other->client->pers.inventory[index] = other->client->pers.max_cells;
+		}
 	}
 
 	item = FindItem("Grenades");
@@ -340,8 +373,12 @@ qboolean Pickup_Pack (edict_t *ent, edict_t *other)
 	{
 		index = ITEM_INDEX(item);
 		other->client->pers.inventory[index] += item->quantity;
+		
+		if(!sv_unlimited_pickup->value)
+		{
 		if (other->client->pers.inventory[index] > other->client->pers.max_grenades)
 			other->client->pers.inventory[index] = other->client->pers.max_grenades;
+		}
 	}
 
 	item = FindItem("Rockets");
@@ -349,8 +386,12 @@ qboolean Pickup_Pack (edict_t *ent, edict_t *other)
 	{
 		index = ITEM_INDEX(item);
 		other->client->pers.inventory[index] += item->quantity;
+		
+		if(!sv_unlimited_pickup->value)
+		{
 		if (other->client->pers.inventory[index] > other->client->pers.max_rockets)
 			other->client->pers.inventory[index] = other->client->pers.max_rockets;
+		}
 	}
 
 	item = FindItem("Slugs");
@@ -358,8 +399,12 @@ qboolean Pickup_Pack (edict_t *ent, edict_t *other)
 	{
 		index = ITEM_INDEX(item);
 		other->client->pers.inventory[index] += item->quantity;
+		
+		if(!sv_unlimited_pickup->value)
+		{
 		if (other->client->pers.inventory[index] > other->client->pers.max_slugs)
 			other->client->pers.inventory[index] = other->client->pers.max_slugs;
+		}
 	}
 //PMM
 	item = FindItem("Flechettes");
@@ -367,8 +412,12 @@ qboolean Pickup_Pack (edict_t *ent, edict_t *other)
 	{
 		index = ITEM_INDEX(item);
 		other->client->pers.inventory[index] += item->quantity;
+	
+		if(!sv_unlimited_pickup->value)
+		{
 		if (other->client->pers.inventory[index] > other->client->pers.max_flechettes)
 			other->client->pers.inventory[index] = other->client->pers.max_flechettes;
+		}
 	}
 #ifndef KILL_DISRUPTOR
 	item = FindItem("Rounds");
@@ -376,8 +425,12 @@ qboolean Pickup_Pack (edict_t *ent, edict_t *other)
 	{
 		index = ITEM_INDEX(item);
 		other->client->pers.inventory[index] += item->quantity;
+
+		if(!sv_unlimited_pickup->value)
+		{
 		if (other->client->pers.inventory[index] > other->client->pers.max_rounds)
 			other->client->pers.inventory[index] = other->client->pers.max_rounds;
+		}
 	}
 #endif
 //pmm
@@ -395,11 +448,15 @@ qboolean Pickup_Nuke (edict_t *ent, edict_t *other)
 //	if (!deathmatch->value)
 //		return;
 	quantity = other->client->pers.inventory[ITEM_INDEX(ent->item)];
+
 //	if ((skill->value == 1 && quantity >= 2) || (skill->value >= 2 && quantity >= 1))
 //		return false;
 
-	if (quantity >= 1)
-		return false;
+		if(!sv_unlimited_pickup->value)
+		{
+			if (quantity >= 1)
+				return false;
+		}
 
 	if ((coop->value) && (ent->item->flags & IT_STAY_COOP) && (quantity > 0))
 		return false;
@@ -526,15 +583,21 @@ qboolean Pickup_Sphere (edict_t *ent, edict_t *other)
 {
 	int		quantity;
 
-	if(other->client && other->client->owned_sphere)
+	if(!sv_unlimited_pickup->value)
 	{
-//		gi.cprintf(other, PRINT_HIGH, "Only one sphere to a customer!\n");
-		return false;
+		if(other->client && other->client->owned_sphere)
+		{
+			gi.cprintf(other, PRINT_HIGH, "Only one sphere to a customer!\n");
+			return false;
+		}
 	}
-
 	quantity = other->client->pers.inventory[ITEM_INDEX(ent->item)];
+
+	if(!sv_unlimited_pickup->value)
+	{
 	if ((skill->value == 1 && quantity >= 2) || (skill->value >= 2 && quantity >= 1))
 		return false;
+	}
 
 	if ((coop->value) && (ent->item->flags & IT_STAY_COOP) && (quantity > 0))
 		return false;
@@ -757,14 +820,19 @@ qboolean Add_Ammo (edict_t *ent, gitem_t *item, int count)
 
 	index = ITEM_INDEX(item);
 
-	if (ent->client->pers.inventory[index] == max)
-		return false;
+	if (!sv_unlimited_pickup->value)
+	{
+		if (ent->client->pers.inventory[index] == max)
+			return false;
+	}
 
 	ent->client->pers.inventory[index] += count;
-
-	if (ent->client->pers.inventory[index] > max)
-		ent->client->pers.inventory[index] = max;
-
+	
+	if (!sv_unlimited_pickup->value)
+	{
+		if (ent->client->pers.inventory[index] > max)
+			ent->client->pers.inventory[index] = max;
+	}
 	return true;
 }
 
@@ -832,13 +900,15 @@ void Drop_Ammo (edict_t *ent, gitem_t *item)
 
 void MegaHealth_think (edict_t *self)
 {
-	if (self->owner->health > self->owner->max_health)
+	if(!sv_unlimited_pickup->value)
 	{
-		self->nextthink = level.time + 1;
-		self->owner->health -= 1;
-		return;
+		if (self->owner->health > self->owner->max_health)
+		{
+			self->nextthink = level.time + 1;			
+			self->owner->health -= 1;						
+			return;
+		}
 	}
-
 	if (!(self->spawnflags & DROPPED_ITEM) && (deathmatch->value))
 		SetRespawn (self, 20);
 	else
@@ -846,11 +916,15 @@ void MegaHealth_think (edict_t *self)
 }
 
 qboolean Pickup_Health (edict_t *ent, edict_t *other)
-{
-	if (!(ent->style & HEALTH_IGNORE_MAX))
-		if (other->health >= other->max_health)
+{	
+	if(!sv_unlimited_pickup->value)
+	{
+		if (!(ent->style & HEALTH_IGNORE_MAX))
+		{
+			if (other->health >= other->max_health)
 			return false;
-
+		}
+	}
 	other->health += ent->count;
 
 	// PMM - health sound fix
@@ -864,13 +938,14 @@ qboolean Pickup_Health (edict_t *ent, edict_t *other)
 	else // (ent->count == 100)
 		ent->item->pickup_sound = "items/m_health.wav";
 	*/
-
-	if (!(ent->style & HEALTH_IGNORE_MAX))
+	if(!sv_unlimited_pickup->value)
 	{
-		if (other->health > other->max_health)
-			other->health = other->max_health;
+		if (!(ent->style & HEALTH_IGNORE_MAX))
+		{
+			if (other->health > other->max_health)
+				other->health = other->max_health;
+		}
 	}
-
 	if (ent->style & HEALTH_TIMED)
 	{
 		ent->think = MegaHealth_think;
@@ -916,12 +991,12 @@ qboolean Pickup_Armor (edict_t *ent, edict_t *other)
 	int				newcount;
 	float			salvage;
 	int				salvagecount;
-
+	
 	// get info on new armor
 	newinfo = (gitem_armor_t *)ent->item->info;
-
+	
 	old_armor_index = ArmorIndex (other);
-
+	
 	// handle armor shards specially
 	if (ent->item->tag == ARMOR_SHARD)
 	{
@@ -930,13 +1005,13 @@ qboolean Pickup_Armor (edict_t *ent, edict_t *other)
 		else
 			other->client->pers.inventory[old_armor_index] += 2;
 	}
-
+	
 	// if player has no armor, just use it
 	else if (!old_armor_index)
 	{
 		other->client->pers.inventory[ITEM_INDEX(ent->item)] = newinfo->base_count;
 	}
-
+	
 	// use the better armor
 	else
 	{
@@ -947,40 +1022,83 @@ qboolean Pickup_Armor (edict_t *ent, edict_t *other)
 			oldinfo = &combatarmor_info;
 		else // (old_armor_index == body_armor_index)
 			oldinfo = &bodyarmor_info;
-
-		if (newinfo->normal_protection > oldinfo->normal_protection)
+		
+		if(sv_unlimited_pickup->value)
 		{
+		/*if (newinfo->normal_protection > oldinfo->normal_protection)
+		{
+		//	calc new armor values
+		//	salvage = oldinfo->normal_protection / newinfo->normal_protection;
+		salvage = newinfo->normal_protection / oldinfo->normal_protection;
+		salvagecount = salvage * other->client->pers.inventory[old_armor_index];
+		newcount = newinfo->base_count + salvagecount;
+		if (newcount > newinfo->max_count)
+		newcount = newinfo->max_count;
+		newcount = newinfo->base_count + other->client->pers.inventory[old_armor_index];
+		
+		  //zero count of old armor so it goes away
+		  other->client->pers.inventory[old_armor_index] = 0;
+		  
+			//change armor to new item with computed value
+			
+			  
+				
+				  other->client->pers.inventory[ITEM_INDEX(ent->item)] = newcount;
+				  
+					}
+					else
+			{*/
 			// calc new armor values
-			salvage = oldinfo->normal_protection / newinfo->normal_protection;
-			salvagecount = salvage * other->client->pers.inventory[old_armor_index];
-			newcount = newinfo->base_count + salvagecount;
-			if (newcount > newinfo->max_count)
-				newcount = newinfo->max_count;
-
-			// zero count of old armor so it goes away
-			other->client->pers.inventory[old_armor_index] = 0;
-
-			// change armor to new item with computed value
-			other->client->pers.inventory[ITEM_INDEX(ent->item)] = newcount;
+			//salvage = newinfo->normal_protection / oldinfo->normal_protection;
+			salvagecount = newinfo->base_count;
+			newcount = other->client->pers.inventory[old_armor_index] + salvagecount;
+			//	if (newcount > oldinfo->max_count)
+			//		newcount = oldinfo->max_count;
+			
+			// if we're already maxed out then we don't need the new armor
+			//if (other->client->pers.inventory[old_armor_index] >= newcount)
+			//	return false;
+			
+			// update current armor value
+			other->client->pers.inventory[old_armor_index] = newcount;
+			//}
 		}
 		else
 		{
-			// calc new armor values
-			salvage = newinfo->normal_protection / oldinfo->normal_protection;
-			salvagecount = salvage * newinfo->base_count;
-			newcount = other->client->pers.inventory[old_armor_index] + salvagecount;
-			if (newcount > oldinfo->max_count)
-				newcount = oldinfo->max_count;
-
-			// if we're already maxed out then we don't need the new armor
-			if (other->client->pers.inventory[old_armor_index] >= newcount)
-				return false;
-
-			// update current armor value
-			other->client->pers.inventory[old_armor_index] = newcount;
+			if (newinfo->normal_protection > oldinfo->normal_protection)
+			{
+				// calc new armor values
+				salvage = oldinfo->normal_protection / newinfo->normal_protection;
+				salvagecount = salvage * other->client->pers.inventory[old_armor_index];
+				newcount = newinfo->base_count + salvagecount;
+				if (newcount > newinfo->max_count)
+					newcount = newinfo->max_count;
+				
+				// zero count of old armor so it goes away
+				other->client->pers.inventory[old_armor_index] = 0;
+				
+				// change armor to new item with computed value
+				other->client->pers.inventory[ITEM_INDEX(ent->item)] = newcount;
+			}
+			else
+			{
+				// calc new armor values
+				salvage = newinfo->normal_protection / oldinfo->normal_protection;
+				salvagecount = salvage * newinfo->base_count;
+				newcount = other->client->pers.inventory[old_armor_index] + salvagecount;
+				if (newcount > oldinfo->max_count)
+					newcount = oldinfo->max_count;
+				
+				// if we're already maxed out then we don't need the new armor
+				if (other->client->pers.inventory[old_armor_index] >= newcount)
+					return false;
+				
+				// update current armor value
+				other->client->pers.inventory[old_armor_index] = newcount;
+			}
 		}
 	}
-
+	
 	if (!(ent->spawnflags & DROPPED_ITEM) && (deathmatch->value))
 		SetRespawn (ent, 20);
 

--- a/rsrc/g_local.h
+++ b/rsrc/g_local.h
@@ -22,7 +22,7 @@
 //==================================================================
 
 #ifndef _WIN32
-//#include <nan.h>
+#include <nan.h>
 #define min(a,b) ((a) < (b) ? (a) : (b))
 #define max(a,b) ((a) > (b) ? (a) : (b))
 #ifdef __sun__
@@ -649,6 +649,7 @@ extern	cvar_t	*bob_pitch;
 extern	cvar_t	*bob_roll;
 
 extern	cvar_t	*sv_cheats;
+extern	cvar_t	*sv_unlimited_pickup;//alex3474247
 extern	cvar_t	*maxclients;
 extern	cvar_t	*maxspectators;
 

--- a/rsrc/g_main.c
+++ b/rsrc/g_main.c
@@ -45,6 +45,7 @@ cvar_t	*bob_pitch;
 cvar_t	*bob_roll;
 
 cvar_t	*sv_cheats;
+cvar_t	*sv_unlimited_pickup;//alex3474247
 
 cvar_t	*flood_msgs;
 cvar_t	*flood_persecond;
@@ -340,8 +341,11 @@ void ExitLevel (void)
 		ent = g_edicts + 1 + i;
 		if (!ent->inuse)
 			continue;
-		if (ent->health > ent->client->pers.max_health)
-			ent->health = ent->client->pers.max_health;
+		if(!sv_unlimited_pickup->value)
+		{
+			if (ent->health > ent->client->pers.max_health)
+				ent->health = ent->client->pers.max_health;
+		}
 	}
 
 }

--- a/rsrc/g_save.c
+++ b/rsrc/g_save.c
@@ -185,6 +185,7 @@ void InitGame (void)
 
 	// latched vars
 	sv_cheats = gi.cvar ("cheats", "0", CVAR_SERVERINFO|CVAR_LATCH);
+	sv_unlimited_pickup = gi.cvar ("unlimited_pickup", "0", CVAR_SERVERINFO|CVAR_LATCH);//alex3474247
 	gi.cvar ("gamename", GAMEVERSION , CVAR_SERVERINFO | CVAR_LATCH);
 	gi.cvar ("gamedate", __DATE__ , CVAR_SERVERINFO | CVAR_LATCH);
 

--- a/xsrc/g_items.c
+++ b/xsrc/g_items.c
@@ -26,9 +26,9 @@ gitem_armor_t jacketarmor_info	= { 25,  50, .30, .00, ARMOR_JACKET};
 gitem_armor_t combatarmor_info	= { 50, 100, .60, .30, ARMOR_COMBAT};
 gitem_armor_t bodyarmor_info	= {100, 200, .80, .60, ARMOR_BODY};
 
- int	jacket_armor_index;
- int	combat_armor_index;
- int	body_armor_index;
+static int	jacket_armor_index;
+static int	combat_armor_index;
+static int	body_armor_index;
 static int	power_screen_index;
 static int	power_shield_index;
 
@@ -152,8 +152,12 @@ qboolean Pickup_Powerup (edict_t *ent, edict_t *other)
 	int		quantity;
 
 	quantity = other->client->pers.inventory[ITEM_INDEX(ent->item)];
+	
+	if(!sv_unlimited_pickup->value)
+	{
 	if ((skill->value == 1 && quantity >= 2) || (skill->value >= 2 && quantity >= 1))
 		return false;
+	}
 
 	if ((coop->value) && (ent->item->flags & IT_STAY_COOP) && (quantity > 0))
 		return false;
@@ -197,8 +201,15 @@ qboolean Pickup_Adrenaline (edict_t *ent, edict_t *other)
 	if (!deathmatch->value)
 		other->max_health += 1;
 
-	if (other->health < other->max_health)
-		other->health = other->max_health;
+	if(!sv_unlimited_pickup->value)
+	{
+		if (other->health < other->max_health)
+			other->health = other->max_health;
+	}
+	else
+	{
+		other->health +=150; 
+	}
 
 	if (!(ent->spawnflags & DROPPED_ITEM) && (deathmatch->value))
 		SetRespawn (ent, ent->item->quantity);
@@ -238,8 +249,12 @@ qboolean Pickup_Bandolier (edict_t *ent, edict_t *other)
 	{
 		index = ITEM_INDEX(item);
 		other->client->pers.inventory[index] += item->quantity;
-		if (other->client->pers.inventory[index] > other->client->pers.max_bullets)
-			other->client->pers.inventory[index] = other->client->pers.max_bullets;
+
+		if(!sv_unlimited_pickup->value)
+		{
+			if (other->client->pers.inventory[index] > other->client->pers.max_bullets)
+				other->client->pers.inventory[index] = other->client->pers.max_bullets;
+		}
 	}
 
 	item = FindItem("Shells");
@@ -247,8 +262,11 @@ qboolean Pickup_Bandolier (edict_t *ent, edict_t *other)
 	{
 		index = ITEM_INDEX(item);
 		other->client->pers.inventory[index] += item->quantity;
-		if (other->client->pers.inventory[index] > other->client->pers.max_shells)
-			other->client->pers.inventory[index] = other->client->pers.max_shells;
+		if(!sv_unlimited_pickup->value)
+		{
+			if (other->client->pers.inventory[index] > other->client->pers.max_shells)
+				other->client->pers.inventory[index] = other->client->pers.max_shells;
+		}
 	}
 
 	if (!(ent->spawnflags & DROPPED_ITEM) && (deathmatch->value))
@@ -283,8 +301,12 @@ qboolean Pickup_Pack (edict_t *ent, edict_t *other)
 	{
 		index = ITEM_INDEX(item);
 		other->client->pers.inventory[index] += item->quantity;
-		if (other->client->pers.inventory[index] > other->client->pers.max_bullets)
-			other->client->pers.inventory[index] = other->client->pers.max_bullets;
+
+		if(!sv_unlimited_pickup->value)
+		{
+			if (other->client->pers.inventory[index] > other->client->pers.max_bullets)
+				other->client->pers.inventory[index] = other->client->pers.max_bullets;
+		}
 	}
 
 	item = FindItem("Shells");
@@ -292,8 +314,12 @@ qboolean Pickup_Pack (edict_t *ent, edict_t *other)
 	{
 		index = ITEM_INDEX(item);
 		other->client->pers.inventory[index] += item->quantity;
-		if (other->client->pers.inventory[index] > other->client->pers.max_shells)
-			other->client->pers.inventory[index] = other->client->pers.max_shells;
+
+		if(!sv_unlimited_pickup->value)
+		{
+			if (other->client->pers.inventory[index] > other->client->pers.max_shells)
+				other->client->pers.inventory[index] = other->client->pers.max_shells;
+		}
 	}
 
 	item = FindItem("Cells");
@@ -301,8 +327,12 @@ qboolean Pickup_Pack (edict_t *ent, edict_t *other)
 	{
 		index = ITEM_INDEX(item);
 		other->client->pers.inventory[index] += item->quantity;
-		if (other->client->pers.inventory[index] > other->client->pers.max_cells)
-			other->client->pers.inventory[index] = other->client->pers.max_cells;
+
+		if(!sv_unlimited_pickup->value)
+		{
+			if (other->client->pers.inventory[index] > other->client->pers.max_cells)
+				other->client->pers.inventory[index] = other->client->pers.max_cells;
+		}
 	}
 
 	item = FindItem("Grenades");
@@ -310,8 +340,12 @@ qboolean Pickup_Pack (edict_t *ent, edict_t *other)
 	{
 		index = ITEM_INDEX(item);
 		other->client->pers.inventory[index] += item->quantity;
-		if (other->client->pers.inventory[index] > other->client->pers.max_grenades)
-			other->client->pers.inventory[index] = other->client->pers.max_grenades;
+		
+		if(!sv_unlimited_pickup->value)
+		{
+			if (other->client->pers.inventory[index] > other->client->pers.max_grenades)
+				other->client->pers.inventory[index] = other->client->pers.max_grenades;
+		}
 	}
 
 	item = FindItem("Rockets");
@@ -319,8 +353,12 @@ qboolean Pickup_Pack (edict_t *ent, edict_t *other)
 	{
 		index = ITEM_INDEX(item);
 		other->client->pers.inventory[index] += item->quantity;
-		if (other->client->pers.inventory[index] > other->client->pers.max_rockets)
-			other->client->pers.inventory[index] = other->client->pers.max_rockets;
+
+		if(!sv_unlimited_pickup->value)
+		{
+			if (other->client->pers.inventory[index] > other->client->pers.max_rockets)
+				other->client->pers.inventory[index] = other->client->pers.max_rockets;
+		}
 	}
 
 	item = FindItem("Slugs");
@@ -328,8 +366,12 @@ qboolean Pickup_Pack (edict_t *ent, edict_t *other)
 	{
 		index = ITEM_INDEX(item);
 		other->client->pers.inventory[index] += item->quantity;
-		if (other->client->pers.inventory[index] > other->client->pers.max_slugs)
-			other->client->pers.inventory[index] = other->client->pers.max_slugs;
+
+		if(!sv_unlimited_pickup->value)
+		{
+			if (other->client->pers.inventory[index] > other->client->pers.max_slugs)
+				other->client->pers.inventory[index] = other->client->pers.max_slugs;
+		}
 	}
 
 	// RAFAEL
@@ -338,8 +380,12 @@ qboolean Pickup_Pack (edict_t *ent, edict_t *other)
 	{
 		index = ITEM_INDEX(item);
 		other->client->pers.inventory[index] += item->quantity;
-		if (other->client->pers.inventory[index] > other->client->pers.max_magslug)
-			other->client->pers.inventory[index] = other->client->pers.max_magslug;
+
+		if(!sv_unlimited_pickup->value)
+		{
+			if (other->client->pers.inventory[index] > other->client->pers.max_magslug)
+				other->client->pers.inventory[index] = other->client->pers.max_magslug;
+		}
 	}
 
 	if (!(ent->spawnflags & DROPPED_ITEM) && (deathmatch->value))
@@ -516,16 +562,22 @@ qboolean Add_Ammo (edict_t *ent, gitem_t *item, int count)
 		max = ent->client->pers.max_trap;
 	else
 		return false;
-
+	
 	index = ITEM_INDEX(item);
 
-	if (ent->client->pers.inventory[index] == max)
-		return false;
+	if (!sv_unlimited_pickup->value)
+	{
+		if (ent->client->pers.inventory[index] == max)
+			return false;
+	}
 
 	ent->client->pers.inventory[index] += count;
 
-	if (ent->client->pers.inventory[index] > max)
-		ent->client->pers.inventory[index] = max;
+	if (!sv_unlimited_pickup->value)
+	{
+		if (ent->client->pers.inventory[index] > max)
+			ent->client->pers.inventory[index] = max;
+	}
 
 	return true;
 }
@@ -589,14 +641,16 @@ void Drop_Ammo (edict_t *ent, gitem_t *item)
 //======================================================================
 
 void MegaHealth_think (edict_t *self)
-{
-	if (self->owner->health > self->owner->max_health)
+{	
+	if(!sv_unlimited_pickup->value)
 	{
-		self->nextthink = level.time + 1;
-		self->owner->health -= 1;
-		return;
+		if (self->owner->health > self->owner->max_health)
+		{
+			self->nextthink = level.time + 1;						
+			self->owner->health -= 1;						
+			return;
+		}
 	}
-
 	if (!(self->spawnflags & DROPPED_ITEM) && (deathmatch->value))
 		SetRespawn (self, 20);
 	else
@@ -606,31 +660,38 @@ void MegaHealth_think (edict_t *self)
 qboolean Pickup_Health (edict_t *ent, edict_t *other)
 {
 	if (!(ent->style & HEALTH_IGNORE_MAX))
-		if (other->health >= other->max_health)
-			return false;
-
-	other->health += ent->count;
-
-	if (!(ent->style & HEALTH_IGNORE_MAX))
 	{
-		if (other->health > other->max_health)
-			other->health = other->max_health;
+		if(!sv_unlimited_pickup->value)
+		{
+			if (other->health >= other->max_health)
+				return false;
+		}
 	}
+		other->health += ent->count;
+		
+		if(!sv_unlimited_pickup->value)
+		{
+			if (!(ent->style & HEALTH_IGNORE_MAX))
+			{
+				if (other->health > other->max_health)
+					other->health = other->max_health;
+			}
+		}
 
-	if (ent->style & HEALTH_TIMED)
-	{
-		ent->think = MegaHealth_think;
-		ent->nextthink = level.time + 5;
-		ent->owner = other;
-		ent->flags |= FL_RESPAWN;
-		ent->svflags |= SVF_NOCLIENT;
-		ent->solid = SOLID_NOT;
-	}
-	else
-	{
-		if (!(ent->spawnflags & DROPPED_ITEM) && (deathmatch->value))
-			SetRespawn (ent, 30);
-	}
+		if (ent->style & HEALTH_TIMED)
+		{
+			ent->think = MegaHealth_think;
+			ent->nextthink = level.time + 5;
+			ent->owner = other;
+			ent->flags |= FL_RESPAWN;
+			ent->svflags |= SVF_NOCLIENT;
+			ent->solid = SOLID_NOT;
+		}
+		else
+		{
+			if (!(ent->spawnflags & DROPPED_ITEM) && (deathmatch->value))
+				SetRespawn (ent, 30);
+		}
 
 	return true;
 }
@@ -676,13 +737,13 @@ qboolean Pickup_Armor (edict_t *ent, edict_t *other)
 		else
 			other->client->pers.inventory[old_armor_index] += 2;
 	}
-
+	
 	// if player has no armor, just use it
 	else if (!old_armor_index)
 	{
 		other->client->pers.inventory[ITEM_INDEX(ent->item)] = newinfo->base_count;
 	}
-
+	
 	// use the better armor
 	else
 	{
@@ -693,37 +754,79 @@ qboolean Pickup_Armor (edict_t *ent, edict_t *other)
 			oldinfo = &combatarmor_info;
 		else // (old_armor_index == body_armor_index)
 			oldinfo = &bodyarmor_info;
-
-		if (newinfo->normal_protection > oldinfo->normal_protection)
+		if(!sv_unlimited_pickup->value)
 		{
+		/*if (newinfo->normal_protection > oldinfo->normal_protection)
+		{
+		//	calc new armor values
+		//	salvage = oldinfo->normal_protection / newinfo->normal_protection;
+		salvage = newinfo->normal_protection / oldinfo->normal_protection;
+		salvagecount = salvage * other->client->pers.inventory[old_armor_index];
+		newcount = newinfo->base_count + salvagecount;
+		if (newcount > newinfo->max_count)
+		newcount = newinfo->max_count;
+		newcount = newinfo->base_count + other->client->pers.inventory[old_armor_index];
+		
+		  //zero count of old armor so it goes away
+		  other->client->pers.inventory[old_armor_index] = 0;
+		  
+			//change armor to new item with computed value
+			
+			  
+				
+				  other->client->pers.inventory[ITEM_INDEX(ent->item)] = newcount;
+				  
+					}
+					else
+			{*/
 			// calc new armor values
-			salvage = oldinfo->normal_protection / newinfo->normal_protection;
-			salvagecount = salvage * other->client->pers.inventory[old_armor_index];
-			newcount = newinfo->base_count + salvagecount;
-			if (newcount > newinfo->max_count)
-				newcount = newinfo->max_count;
-
-			// zero count of old armor so it goes away
-			other->client->pers.inventory[old_armor_index] = 0;
-
-			// change armor to new item with computed value
-			other->client->pers.inventory[ITEM_INDEX(ent->item)] = newcount;
+			//salvage = newinfo->normal_protection / oldinfo->normal_protection;
+			salvagecount = newinfo->base_count;
+			newcount = other->client->pers.inventory[old_armor_index] + salvagecount;
+			//if (newcount > oldinfo->max_count)
+			//	newcount = oldinfo->max_count;
+			
+			// if we're already maxed out then we don't need the new armor
+			//if (other->client->pers.inventory[old_armor_index] >= newcount)
+			//	return false;
+			
+			// update current armor value
+			other->client->pers.inventory[old_armor_index] = newcount;
+			//}
 		}
 		else
 		{
-			// calc new armor values
-			salvage = newinfo->normal_protection / oldinfo->normal_protection;
-			salvagecount = salvage * newinfo->base_count;
-			newcount = other->client->pers.inventory[old_armor_index] + salvagecount;
-			if (newcount > oldinfo->max_count)
-				newcount = oldinfo->max_count;
-
-			// if we're already maxed out then we don't need the new armor
-			if (other->client->pers.inventory[old_armor_index] >= newcount)
-				return false;
-
-			// update current armor value
-			other->client->pers.inventory[old_armor_index] = newcount;
+			if (newinfo->normal_protection > oldinfo->normal_protection)
+			{
+				// calc new armor values
+				salvage = oldinfo->normal_protection / newinfo->normal_protection;
+				salvagecount = salvage * other->client->pers.inventory[old_armor_index];
+				newcount = newinfo->base_count + salvagecount;
+				if (newcount > newinfo->max_count)
+					newcount = newinfo->max_count;
+				
+				// zero count of old armor so it goes away
+				other->client->pers.inventory[old_armor_index] = 0;
+				
+				// change armor to new item with computed value
+				other->client->pers.inventory[ITEM_INDEX(ent->item)] = newcount;
+			}
+			else
+			{
+				// calc new armor values
+				salvage = newinfo->normal_protection / oldinfo->normal_protection;
+				salvagecount = salvage * newinfo->base_count;
+				newcount = other->client->pers.inventory[old_armor_index] + salvagecount;
+				if (newcount > oldinfo->max_count)
+					newcount = oldinfo->max_count;
+				
+				// if we're already maxed out then we don't need the new armor
+				if (other->client->pers.inventory[old_armor_index] >= newcount)
+					return false;
+				
+				// update current armor value
+				other->client->pers.inventory[old_armor_index] = newcount;
+			}
 		}
 	}
 

--- a/xsrc/g_local.h
+++ b/xsrc/g_local.h
@@ -537,6 +537,7 @@ extern	cvar_t	*bob_pitch;
 extern	cvar_t	*bob_roll;
 
 extern	cvar_t	*sv_cheats;
+extern	cvar_t	*sv_unlimited_pickup;//alex3474247
 extern	cvar_t	*maxclients;
 extern	cvar_t	*maxspectators;
 

--- a/xsrc/g_main.c
+++ b/xsrc/g_main.c
@@ -45,6 +45,7 @@ cvar_t	*bob_pitch;
 cvar_t	*bob_roll;
 
 cvar_t	*sv_cheats;
+cvar_t	*sv_unlimited_pickup;//alex3474247
 
 cvar_t	*flood_msgs;
 cvar_t	*flood_persecond;
@@ -320,8 +321,11 @@ void ExitLevel (void)
 		ent = g_edicts + 1 + i;
 		if (!ent->inuse)
 			continue;
-		if (ent->health > ent->client->pers.max_health)
-			ent->health = ent->client->pers.max_health;
+		if (!sv_unlimited_pickup->value)
+		{
+			if (ent->health > ent->client->pers.max_health)
+				ent->health = ent->client->pers.max_health;
+		}
 	}
 
 }

--- a/xsrc/g_save.c
+++ b/xsrc/g_save.c
@@ -151,6 +151,7 @@ void InitGame (void)
 
 	// latched vars
 	sv_cheats = gi.cvar ("cheats", "0", CVAR_SERVERINFO|CVAR_LATCH);
+	sv_unlimited_pickup = gi.cvar ("unlimited_pickup", "0", CVAR_SERVERINFO|CVAR_LATCH);//alex3474247
 	gi.cvar ("gamename", GAMEVERSION , CVAR_SERVERINFO | CVAR_LATCH);
 	gi.cvar ("gamedate", __DATE__ , CVAR_SERVERINFO | CVAR_LATCH);
 


### PR DESCRIPTION
… ammo, health and armor. Checked - this should work OK, i debugged it in an old visual studio 6.0 and it worked properly. Quake 2 is easier than Quake 1 because the HUD font is small enough to fit 5-digit health value. In Quake 1 it's big.